### PR TITLE
Fix app_example_tx so it sends the sample frequency / master clock frequency

### DIFF
--- a/app_example_tx/src/main.xc
+++ b/app_example_tx/src/main.xc
@@ -6,6 +6,9 @@
 #include <xs1.h>
 #include "SpdifTransmit.h"
 
+#define SAMPLE_FREQUENCY_HZ 48000
+#define MASTER_CLOCK_FREQUENCY_HZ 24576000
+
 buffered out port:32 oneBitPort = XS1_PORT_1F;
 in port masterClockPort = XS1_PORT_1E;
 clock clockblock = XS1_CLKBLK_1;
@@ -16,6 +19,8 @@ void transmitSpdif(chanend c)  {
 }
 
 void generate(chanend c) {
+    outuint(c, SAMPLE_FREQUENCY_HZ);
+    outuint(c, MASTER_CLOCK_FREQUENCY_HZ);
     for(int i = 0; i < 10; i++) {
         outuint(c, i);
     }


### PR DESCRIPTION
The first two words sent to SpdifTransmit must be the sample frequency and the master clock frequency. Update app_example_tx to send this information.
